### PR TITLE
Develop various moving rules

### DIFF
--- a/src/controller/MainViewController.java
+++ b/src/controller/MainViewController.java
@@ -2,6 +2,7 @@ package controller;
 
 import model.game.Game;
 import model.game.PlayerType;
+import model.move_finder.MoveFinderSettings;
 import view.MainView;
 
 public class MainViewController {
@@ -16,7 +17,8 @@ public class MainViewController {
 
     public void newGame(PlayerType whitePlayerType, PlayerType blackPlayerType, int boardSize) {
         Game game = new Game(boardController, this);
-        game.newGame(whitePlayerType, blackPlayerType, boardSize);
+        MoveFinderSettings moveFinderSettings = new MoveFinderSettings(mainView.isFlyingKingEnabled(), mainView.isCheckerBeatingBackwardEnabled());
+        game.newGame(whitePlayerType, blackPlayerType, boardSize, moveFinderSettings);
     }
 
     public void setResult(String resultText) {

--- a/src/model/game/Game.java
+++ b/src/model/game/Game.java
@@ -9,6 +9,7 @@ import model.bot.RandomPieceBot;
 import model.input_handler.BotInputHandler;
 import model.input_handler.InputHandler;
 import model.input_handler.PlayerInputHandler;
+import model.move_finder.MoveFinderSettings;
 import model.move_finder.PossibleMovesFinder;
 
 import java.util.List;
@@ -38,7 +39,9 @@ public class Game {
     public void newGame(PlayerType whitePlayer, PlayerType blackPlayer, int boardSideLength) {
         gameStorage = new GameStorage(boardSideLength);
 
-        possibleMovesFinder = new PossibleMovesFinder(boardSideLength);
+        //TODO read move finder settings from board
+        MoveFinderSettings moveFinderSettings = new MoveFinderSettings(true, true);
+        possibleMovesFinder = new PossibleMovesFinder(moveFinderSettings, boardSideLength);
 
         whiteInputHandler = generateInputHandler(whitePlayer);
         blackInputHandler = generateInputHandler(blackPlayer);

--- a/src/model/game/Game.java
+++ b/src/model/game/Game.java
@@ -36,11 +36,9 @@ public class Game {
 
     }
 
-    public void newGame(PlayerType whitePlayer, PlayerType blackPlayer, int boardSideLength) {
+    public void newGame(PlayerType whitePlayer, PlayerType blackPlayer, int boardSideLength, MoveFinderSettings moveFinderSettings) {
         gameStorage = new GameStorage(boardSideLength);
 
-        //TODO read move finder settings from board
-        MoveFinderSettings moveFinderSettings = new MoveFinderSettings(true, true);
         possibleMovesFinder = new PossibleMovesFinder(moveFinderSettings, boardSideLength);
 
         whiteInputHandler = generateInputHandler(whitePlayer);

--- a/src/model/move_finder/BasicBitSets.java
+++ b/src/model/move_finder/BasicBitSets.java
@@ -1,0 +1,29 @@
+package model.move_finder;
+
+import java.util.BitSet;
+
+public class BasicBitSets {
+    private BitSet freeTileNumbers;
+    private BitSet ownCheckers;
+    private BitSet ownKings;
+    private BitSet enemyPieces;
+
+    public BasicBitSets() {
+    }
+
+    public BitSet getFreeTileNumbers() {
+        return freeTileNumbers;
+    }
+
+    public BitSet getOwnCheckers() {
+        return ownCheckers;
+    }
+
+    public BitSet getOwnKings() {
+        return ownKings;
+    }
+
+    public BitSet getEnemyPieces() {
+        return enemyPieces;
+    }
+}

--- a/src/model/move_finder/BasicBitSets.java
+++ b/src/model/move_finder/BasicBitSets.java
@@ -1,5 +1,7 @@
 package model.move_finder;
 
+import model.board.Position;
+
 import java.util.BitSet;
 
 public class BasicBitSets {
@@ -8,7 +10,21 @@ public class BasicBitSets {
     private BitSet ownKings;
     private BitSet enemyPieces;
 
-    public BasicBitSets() {
+    public BasicBitSets(Position position, boolean isWhiteMove, BitwiseOperator bitwiseOperator) {
+        BitSet ownPieces;
+        if (isWhiteMove) {
+            ownPieces = position.getWhitePieces();
+            enemyPieces = (BitSet) position.getBlackPieces().clone();
+        } else {
+            ownPieces = position.getBlackPieces();
+            enemyPieces = (BitSet) position.getWhitePieces().clone();
+        }
+
+        freeTileNumbers = bitwiseOperator.merge(position.getWhitePieces(), position.getBlackPieces());
+        freeTileNumbers.flip(0, freeTileNumbers.size());
+        freeTileNumbers.and(bitwiseOperator.getExistingTileNumbers());
+        ownCheckers = bitwiseOperator.getOwnCheckers(ownPieces, position.getKings());
+        ownKings = bitwiseOperator.getOwnKings(ownPieces, position.getKings());
     }
 
     public BitSet getFreeTileNumbers() {

--- a/src/model/move_finder/DirectionsValueBySize.java
+++ b/src/model/move_finder/DirectionsValueBySize.java
@@ -1,0 +1,19 @@
+package model.move_finder;
+
+public enum DirectionsValueBySize {
+    BOARD_OF_SIZE_EIGHT(4, 5, -5, -4),
+    BOARD_OF_SIZE_TEN(5, 6, -6, -5),
+    BOARD_OF_SIZE_TWELVE(6, 7, -7, -6);
+
+    DirectionsValueBySize(int upperRight, int upperLeft, int lowerRight, int lowerLeft) {
+        this.upperRight = upperRight;
+        this.upperLeft = upperLeft;
+        this.lowerRight = lowerRight;
+        this.lowerLeft = lowerLeft;
+    }
+
+    int upperRight;
+    int upperLeft;
+    int lowerRight;
+    int lowerLeft;
+}

--- a/src/model/move_finder/DirectionsValueBySize.java
+++ b/src/model/move_finder/DirectionsValueBySize.java
@@ -12,8 +12,8 @@ public enum DirectionsValueBySize {
         this.lowerLeft = lowerLeft;
     }
 
-    int upperRight;
-    int upperLeft;
-    int lowerRight;
-    int lowerLeft;
+    public int upperRight;
+    public int upperLeft;
+    public int lowerRight;
+    public int lowerLeft;
 }

--- a/src/model/move_finder/MoveFinderSettings.java
+++ b/src/model/move_finder/MoveFinderSettings.java
@@ -1,0 +1,19 @@
+package model.move_finder;
+
+public class MoveFinderSettings {
+    private boolean isFlyingKingEnabled;
+    private boolean isCheckerBeatingBackwardsEnabled;
+
+    public MoveFinderSettings(boolean isFlyingKingEnabled, boolean isCheckerBeatingBackwardsEnabled) {
+        this.isFlyingKingEnabled = isFlyingKingEnabled;
+        this.isCheckerBeatingBackwardsEnabled = isCheckerBeatingBackwardsEnabled;
+    }
+
+    public boolean isFlyingKingEnabled() {
+        return isFlyingKingEnabled;
+    }
+
+    public boolean isCheckerBeatingBackwardsEnabled() {
+        return isCheckerBeatingBackwardsEnabled;
+    }
+}

--- a/src/model/move_finder/PossibleMovesFinder.java
+++ b/src/model/move_finder/PossibleMovesFinder.java
@@ -74,10 +74,20 @@ public class PossibleMovesFinder {
     }
 
     private void findAStandardBeatingFromCurrentMoveSequence(Move move) {
-        findAStandardBeatingInDirection(move, directions.upperLeft);
-        findAStandardBeatingInDirection(move, directions.upperRight);
-        findAStandardBeatingInDirection(move, directions.lowerRight);
-        findAStandardBeatingInDirection(move, directions.lowerLeft);
+        if (moveFinderSettings.isCheckerBeatingBackwardsEnabled()) {
+            findAStandardBeatingInDirection(move, directions.upperLeft);
+            findAStandardBeatingInDirection(move, directions.upperRight);
+            findAStandardBeatingInDirection(move, directions.lowerRight);
+            findAStandardBeatingInDirection(move, directions.lowerLeft);
+        } else {
+            if (isWhiteMove) {
+                findAStandardBeatingInDirection(move, directions.upperLeft);
+                findAStandardBeatingInDirection(move, directions.upperRight);
+            } else {
+                findAStandardBeatingInDirection(move, directions.lowerRight);
+                findAStandardBeatingInDirection(move, directions.lowerLeft);
+            }
+        }
     }
 
     private void findAStandardBeatingInDirection(Move move, int direction) {

--- a/src/model/move_finder/PossibleMovesFinder.java
+++ b/src/model/move_finder/PossibleMovesFinder.java
@@ -60,7 +60,6 @@ public class PossibleMovesFinder {
     }
 
     public List<Move> getAvailableMovesFrom(Position position, boolean isWhiteMove) {
-
         this.isWhiteMove = isWhiteMove;
         availableMoves = new LinkedList<>();
         currentBeatingLength = 0;

--- a/src/model/move_finder/PossibleMovesFinder.java
+++ b/src/model/move_finder/PossibleMovesFinder.java
@@ -105,7 +105,13 @@ public class PossibleMovesFinder {
             Move move = new Move();
             move.addNewTileNumberToMoveSequence(kingPosition);
             basicBitSets.getFreeTileNumbers().set(kingPosition);
-            findAFlyingBeatingFromCurrentMoveSequence(move, 0);
+
+            if (moveFinderSettings.isFlyingKingEnabled()) {
+                findAFlyingBeatingFromCurrentMoveSequence(move, 0);
+            } else {
+                findAStandardBeatingFromCurrentMoveSequence(move);
+            }
+
             basicBitSets.getFreeTileNumbers().clear(kingPosition);
         }
     }

--- a/src/model/move_finder/PossibleMovesFinder.java
+++ b/src/model/move_finder/PossibleMovesFinder.java
@@ -105,12 +105,12 @@ public class PossibleMovesFinder {
             Move move = new Move();
             move.addNewTileNumberToMoveSequence(kingPosition);
             basicBitSets.getFreeTileNumbers().set(kingPosition);
-            findAPromotedBeatingFromCurrentMoveSequence(move, 0);
+            findAFlyingBeatingFromCurrentMoveSequence(move, 0);
             basicBitSets.getFreeTileNumbers().clear(kingPosition);
         }
     }
 
-    private void findAPromotedBeatingFromCurrentMoveSequence(Move move, int comingDirection) {
+    private void findAFlyingBeatingFromCurrentMoveSequence(Move move, int comingDirection) {
         if (comingDirection != directions.lowerLeft) checkForPromotedBeatingInDirection(move, directions.upperRight);
         if (comingDirection != directions.lowerRight) checkForPromotedBeatingInDirection(move, directions.upperLeft);
         if (comingDirection != directions.upperRight) checkForPromotedBeatingInDirection(move, directions.lowerLeft);
@@ -132,7 +132,7 @@ public class PossibleMovesFinder {
                 updatedMove.addNewTileNumberToMoveSequence(expectedFreeTileNumber);
                 updateAvailableMoves(updatedMove);
 
-                findAPromotedBeatingFromCurrentMoveSequence(updatedMove, direction);
+                findAFlyingBeatingFromCurrentMoveSequence(updatedMove, direction);
 
                 expectedFreeTileNumber += direction;
             }

--- a/src/model/move_finder/PossibleMovesFinder.java
+++ b/src/model/move_finder/PossibleMovesFinder.java
@@ -18,8 +18,8 @@ import java.util.*;
 public class PossibleMovesFinder {
     private int upperRight;
     private int upperLeft;
-    private int lowerRight = -5;
-    private int lowerLeft = -4;
+    private int lowerRight;
+    private int lowerLeft;
 
     private MoveFinderSettings moveFinderSettings;
     private int currentBeatingLength;

--- a/src/model/move_finder/PossibleMovesFinder.java
+++ b/src/model/move_finder/PossibleMovesFinder.java
@@ -174,10 +174,17 @@ public class PossibleMovesFinder {
 
 
     private void checkForPromotedMoves() {
-        checkForFlyingMoveInDirection(directions.upperRight);
-        checkForFlyingMoveInDirection(directions.upperLeft);
-        checkForFlyingMoveInDirection(directions.lowerRight);
-        checkForFlyingMoveInDirection(directions.lowerLeft);
+        if (moveFinderSettings.isFlyingKingEnabled()) {
+            checkForFlyingMoveInDirection(directions.upperRight);
+            checkForFlyingMoveInDirection(directions.upperLeft);
+            checkForFlyingMoveInDirection(directions.lowerRight);
+            checkForFlyingMoveInDirection(directions.lowerLeft);
+        } else {
+            checkForStandardMoveInDirection(basicBitSets.getOwnKings(), directions.upperLeft);
+            checkForStandardMoveInDirection(basicBitSets.getOwnKings(), directions.upperRight);
+            checkForStandardMoveInDirection(basicBitSets.getOwnKings(), directions.lowerLeft);
+            checkForStandardMoveInDirection(basicBitSets.getOwnKings(), directions.lowerRight);
+        }
     }
 
     private void checkForFlyingMoveInDirection(int direction) {
@@ -199,17 +206,17 @@ public class PossibleMovesFinder {
 
     private void checkForStandardMove() {
         if (isWhiteMove) {
-            checkForStandardMoveInDirection(directions.upperLeft);
-            checkForStandardMoveInDirection(directions.upperRight);
+            checkForStandardMoveInDirection(basicBitSets.getOwnCheckers(), directions.upperLeft);
+            checkForStandardMoveInDirection(basicBitSets.getOwnCheckers(), directions.upperRight);
         } else {
-            checkForStandardMoveInDirection(directions.lowerLeft);
-            checkForStandardMoveInDirection(directions.lowerRight);
+            checkForStandardMoveInDirection(basicBitSets.getOwnCheckers(), directions.lowerLeft);
+            checkForStandardMoveInDirection(basicBitSets.getOwnCheckers(), directions.lowerRight);
         }
 
     }
 
-    private void checkForStandardMoveInDirection(int direction) {
-        BitSet shiftedCopy = bitwiseOperator.getShiftedCopy(basicBitSets.getOwnCheckers(), direction);
+    private void checkForStandardMoveInDirection(BitSet piecesToCheck, int direction) {
+        BitSet shiftedCopy = bitwiseOperator.getShiftedCopy(piecesToCheck, direction);
         shiftedCopy.and(basicBitSets.getFreeTileNumbers());
 
         for (int i = shiftedCopy.nextSetBit(0); i >= 0; i = shiftedCopy.nextSetBit(i + 1)) {

--- a/src/model/move_finder/PossibleMovesFinder.java
+++ b/src/model/move_finder/PossibleMovesFinder.java
@@ -73,21 +73,22 @@ public class PossibleMovesFinder {
         }
     }
 
-    private void findAStandardBeatingFromCurrentMoveSequence(Move move) {
-        if (moveFinderSettings.isCheckerBeatingBackwardsEnabled()) {
+
+    private void findAForwardBeatingFromCurrentMoveSequence(Move move) {
+        if (isWhiteMove) {
             findAStandardBeatingInDirection(move, directions.upperLeft);
             findAStandardBeatingInDirection(move, directions.upperRight);
+        } else {
             findAStandardBeatingInDirection(move, directions.lowerRight);
             findAStandardBeatingInDirection(move, directions.lowerLeft);
-        } else {
-            if (isWhiteMove) {
-                findAStandardBeatingInDirection(move, directions.upperLeft);
-                findAStandardBeatingInDirection(move, directions.upperRight);
-            } else {
-                findAStandardBeatingInDirection(move, directions.lowerRight);
-                findAStandardBeatingInDirection(move, directions.lowerLeft);
-            }
         }
+    }
+
+    private void findAStandardBeatingFromCurrentMoveSequence(Move move) {
+        findAStandardBeatingInDirection(move, directions.upperLeft);
+        findAStandardBeatingInDirection(move, directions.upperRight);
+        findAStandardBeatingInDirection(move, directions.lowerRight);
+        findAStandardBeatingInDirection(move, directions.lowerLeft);
     }
 
     private void findAStandardBeatingInDirection(Move move, int direction) {
@@ -104,7 +105,11 @@ public class PossibleMovesFinder {
 
                 updateAvailableMoves(foundMove);
 
-                findAStandardBeatingFromCurrentMoveSequence(foundMove);
+                if (moveFinderSettings.isCheckerBeatingBackwardsEnabled()) {
+                    findAStandardBeatingFromCurrentMoveSequence(foundMove);
+                } else {
+                    findAForwardBeatingFromCurrentMoveSequence(move);
+                }
 
                 basicBitSets.getEnemyPieces().set(expectedEnemyTileNumber);
             }

--- a/src/model/move_finder/PossibleMovesFinder.java
+++ b/src/model/move_finder/PossibleMovesFinder.java
@@ -16,17 +16,13 @@ import java.util.*;
         |08  07  06  05  |
 */
 public class PossibleMovesFinder {
-    private int upperRight;
-    private int upperLeft;
-    private int lowerRight;
-    private int lowerLeft;
-
     private MoveFinderSettings moveFinderSettings;
     private int currentBeatingLength;
     private BitwiseOperator bitwiseOperator;
     private List<Move> availableMoves;
     private boolean isWhiteMove;
     private BasicBitSets basicBitSets;
+    private DirectionsValueBySize directions;
 
 
     public PossibleMovesFinder(MoveFinderSettings moveFinderSettings, int boardSideLength) {
@@ -38,21 +34,15 @@ public class PossibleMovesFinder {
     private void declareProperDirections(int boardSideLength) {
         switch (boardSideLength) {
             case 8:
-                upperRight = 4;
-                upperLeft = 5;
+                directions = DirectionsValueBySize.BOARD_OF_SIZE_EIGHT;
                 break;
             case 10:
-                upperRight = 5;
-                upperLeft = 6;
+                directions = DirectionsValueBySize.BOARD_OF_SIZE_TEN;
                 break;
             case 12:
-                upperRight = 6;
-                upperLeft = 7;
+                directions = DirectionsValueBySize.BOARD_OF_SIZE_TWELVE;
                 break;
         }
-
-        lowerRight = (-1) * upperLeft;
-        lowerLeft = (-1) * upperRight;
     }
 
     public List<Move> getAvailableMovesFrom(Position position, boolean isWhiteMove) {
@@ -84,10 +74,10 @@ public class PossibleMovesFinder {
     }
 
     private void findAStandardBeatingFromCurrentMoveSequence(Move move) {
-        findAStandardBeatingInDirection(move, upperLeft);
-        findAStandardBeatingInDirection(move, upperRight);
-        findAStandardBeatingInDirection(move, lowerRight);
-        findAStandardBeatingInDirection(move, lowerLeft);
+        findAStandardBeatingInDirection(move, directions.upperLeft);
+        findAStandardBeatingInDirection(move, directions.upperRight);
+        findAStandardBeatingInDirection(move, directions.lowerRight);
+        findAStandardBeatingInDirection(move, directions.lowerLeft);
     }
 
     private void findAStandardBeatingInDirection(Move move, int direction) {
@@ -121,10 +111,10 @@ public class PossibleMovesFinder {
     }
 
     private void findAPromotedBeatingFromCurrentMoveSequence(Move move, int comingDirection) {
-        if (comingDirection != lowerLeft) checkForPromotedBeatingInDirection(move, upperRight);
-        if (comingDirection != lowerRight) checkForPromotedBeatingInDirection(move, upperLeft);
-        if (comingDirection != upperRight) checkForPromotedBeatingInDirection(move, lowerLeft);
-        if (comingDirection != upperLeft) checkForPromotedBeatingInDirection(move, lowerRight);
+        if (comingDirection != directions.lowerLeft) checkForPromotedBeatingInDirection(move, directions.upperRight);
+        if (comingDirection != directions.lowerRight) checkForPromotedBeatingInDirection(move, directions.upperLeft);
+        if (comingDirection != directions.upperRight) checkForPromotedBeatingInDirection(move, directions.lowerLeft);
+        if (comingDirection != directions.upperLeft) checkForPromotedBeatingInDirection(move, directions.lowerRight);
     }
 
     private void checkForPromotedBeatingInDirection(Move move, int direction) {
@@ -178,10 +168,10 @@ public class PossibleMovesFinder {
 
 
     private void checkForPromotedMoves() {
-        checkForFlyingMoveInDirection(upperRight);
-        checkForFlyingMoveInDirection(upperLeft);
-        checkForFlyingMoveInDirection(lowerRight);
-        checkForFlyingMoveInDirection(lowerLeft);
+        checkForFlyingMoveInDirection(directions.upperRight);
+        checkForFlyingMoveInDirection(directions.upperLeft);
+        checkForFlyingMoveInDirection(directions.lowerRight);
+        checkForFlyingMoveInDirection(directions.lowerLeft);
     }
 
     private void checkForFlyingMoveInDirection(int direction) {
@@ -203,11 +193,11 @@ public class PossibleMovesFinder {
 
     private void checkForStandardMove() {
         if (isWhiteMove) {
-            checkFrStandardMoveInDirection(upperLeft);
-            checkFrStandardMoveInDirection(upperRight);
+            checkFrStandardMoveInDirection(directions.upperLeft);
+            checkFrStandardMoveInDirection(directions.upperRight);
         } else {
-            checkFrStandardMoveInDirection(lowerLeft);
-            checkFrStandardMoveInDirection(lowerRight);
+            checkFrStandardMoveInDirection(directions.lowerLeft);
+            checkFrStandardMoveInDirection(directions.lowerRight);
         }
 
     }

--- a/src/model/move_finder/PossibleMovesFinder.java
+++ b/src/model/move_finder/PossibleMovesFinder.java
@@ -2,6 +2,10 @@ package model.move_finder;
 
 import model.board.Move;
 import model.board.Position;
+import model.move_finder.move_finder_beating_strategy.FlyingBeating;
+import model.move_finder.move_finder_beating_strategy.ForwardBeating;
+import model.move_finder.move_finder_beating_strategy.MoveFinderBeatingStrategy;
+import model.move_finder.move_finder_beating_strategy.StandardBeating;
 
 import java.util.*;
 
@@ -17,18 +21,24 @@ import java.util.*;
 */
 public class PossibleMovesFinder {
     private MoveFinderSettings moveFinderSettings;
-    private int currentBeatingLength;
+    private int currentLongestMoveLength;
     private BitwiseOperator bitwiseOperator;
     private List<Move> availableMoves;
     private boolean isWhiteMove;
     private BasicBitSets basicBitSets;
     private DirectionsValueBySize directions;
+    private MoveFinderBeatingStrategy checkerBeatingStrategy;
+    private MoveFinderBeatingStrategy kingBeatingStrategy;
+
 
 
     public PossibleMovesFinder(MoveFinderSettings moveFinderSettings, int boardSideLength) {
         this.moveFinderSettings = moveFinderSettings;
         bitwiseOperator = new BitwiseOperator(boardSideLength);
+
         declareProperDirections(boardSideLength);
+        chooseCheckerBeatingStrategies();
+        chooseKingBeatingStrategies();
     }
 
     private void declareProperDirections(int boardSideLength) {
@@ -45,199 +55,78 @@ public class PossibleMovesFinder {
         }
     }
 
+    private void chooseCheckerBeatingStrategies() {
+        if (moveFinderSettings.isFlyingKingEnabled()) {
+            kingBeatingStrategy = new FlyingBeating(directions);
+        } else {
+            kingBeatingStrategy = new StandardBeating(directions);
+        }
+    }
+
+    private void chooseKingBeatingStrategies() {
+        if (moveFinderSettings.isCheckerBeatingBackwardsEnabled()) {
+            checkerBeatingStrategy = new StandardBeating(directions);
+        } else {
+            checkerBeatingStrategy = new ForwardBeating(directions);
+        }
+    }
+
     public List<Move> getAvailableMovesFrom(Position position, boolean isWhiteMove) {
         this.isWhiteMove = isWhiteMove;
         prepareBasicBitSets(position, isWhiteMove);
         availableMoves = new LinkedList<>();
-        currentBeatingLength = 0;
-        prepareBasicBitSets(position, isWhiteMove);
+        currentLongestMoveLength = 0;
 
-        if (!basicBitSets.getOwnKings().isEmpty()) checkForPromotedBeating();
-        if (!basicBitSets.getOwnCheckers().isEmpty()) checkForStandardBeating();
+        checkerBeatingStrategy.setForwardDirection(isWhiteMove);
 
-        if (noBeatingWasFound()) {
-            if (!basicBitSets.getOwnKings().isEmpty()) checkForPromotedMoves();
-            if (!basicBitSets.getOwnCheckers().isEmpty()) checkForStandardMove();
-        }
+        checkForMoves();
 
         return availableMoves;
     }
 
-    private void checkForStandardBeating() {
-        for (int checkerPositionIndex = basicBitSets.getOwnCheckers().nextSetBit(0); checkerPositionIndex >= 0; checkerPositionIndex = basicBitSets.getOwnCheckers().nextSetBit(checkerPositionIndex + 1)) {
-            basicBitSets.getFreeTileNumbers().set(checkerPositionIndex);
-            Move move = new Move();
-            move.addNewTileNumberToMoveSequence(checkerPositionIndex);
-            findAStandardBeatingFromCurrentMoveSequence(move);
-            basicBitSets.getFreeTileNumbers().clear(checkerPositionIndex);
+    private void checkForMoves() {
+        checkForCheckersBeating();
+        checkForKingsBeating();
+
+        if (noBeatingWasFound()) {
+            checkForCheckersMove();
+            checkForKingsMove();
+        }
+    }
+
+    private void checkForKingsMove() {
+
+    }
+
+    private void checkForCheckersMove() {
+    }
+
+    private void checkForCheckersBeating() {
+        for (int checkerTileNumber = basicBitSets.getOwnCheckers().nextSetBit(0); checkerTileNumber >= 0; checkerTileNumber = basicBitSets.getOwnCheckers().nextSetBit(checkerTileNumber + 1)) {
+            List<Move> foundMoves = checkerBeatingStrategy.checkForBeatingMoves(checkerTileNumber, basicBitSets);
+            updateAvailableMoves(foundMoves);
+        }
+    }
+
+    private void checkForKingsBeating() {
+        for (int kingTileNumber = basicBitSets.getOwnKings().nextSetBit(0); kingTileNumber >= 0; kingTileNumber = basicBitSets.getOwnKings().nextSetBit(kingTileNumber + 1)) {
+            List<Move> foundMoves = kingBeatingStrategy.checkForBeatingMoves(kingTileNumber, basicBitSets);
+            updateAvailableMoves(foundMoves);
         }
     }
 
 
-    private void findAForwardBeatingFromCurrentMoveSequence(Move move) {
-        if (isWhiteMove) {
-            findAStandardBeatingInDirection(move, directions.upperLeft);
-            findAStandardBeatingInDirection(move, directions.upperRight);
-        } else {
-            findAStandardBeatingInDirection(move, directions.lowerRight);
-            findAStandardBeatingInDirection(move, directions.lowerLeft);
-        }
-    }
+    private void updateAvailableMoves(List<Move> foundMoves) {
+        if (!foundMoves.isEmpty()) {
+            int foundMoveSize = foundMoves.get(0).size();
 
-    private void findAStandardBeatingFromCurrentMoveSequence(Move move) {
-        findAStandardBeatingInDirection(move, directions.upperLeft);
-        findAStandardBeatingInDirection(move, directions.upperRight);
-        findAStandardBeatingInDirection(move, directions.lowerRight);
-        findAStandardBeatingInDirection(move, directions.lowerLeft);
-    }
-
-    private void findAStandardBeatingInDirection(Move move, int direction) {
-        int expectedEnemyTileNumber = move.getLastPositionOfThePiece() + direction;
-        int expectedFreeTileNumber = expectedEnemyTileNumber + direction;
-
-        if (basicBitSets.getEnemyPieces().get(expectedEnemyTileNumber))
-            if (basicBitSets.getFreeTileNumbers().get(expectedFreeTileNumber)) {
-                basicBitSets.getEnemyPieces().clear(expectedEnemyTileNumber);
-
-                Move foundMove = move.getCopy();
-                foundMove.addNewTileNumberToMoveSequence(expectedEnemyTileNumber);
-                foundMove.addNewTileNumberToMoveSequence(expectedFreeTileNumber);
-
-                updateAvailableMoves(foundMove);
-
-                if (moveFinderSettings.isCheckerBeatingBackwardsEnabled()) {
-                    findAStandardBeatingFromCurrentMoveSequence(foundMove);
-                } else {
-                    findAForwardBeatingFromCurrentMoveSequence(move);
-                }
-
-                basicBitSets.getEnemyPieces().set(expectedEnemyTileNumber);
+            if (foundMoveSize > currentLongestMoveLength) {
+                availableMoves.clear();
+                availableMoves = foundMoves;
+            } else if (foundMoveSize == currentLongestMoveLength){
+                availableMoves.addAll(foundMoves);
             }
-    }
-
-    private void checkForPromotedBeating() {
-        for (int kingPosition = basicBitSets.getOwnKings().nextSetBit(0); kingPosition >= 0; kingPosition = basicBitSets.getOwnKings().nextSetBit(kingPosition + 1)) {
-            Move move = new Move();
-            move.addNewTileNumberToMoveSequence(kingPosition);
-            basicBitSets.getFreeTileNumbers().set(kingPosition);
-
-            if (moveFinderSettings.isFlyingKingEnabled()) {
-                findAFlyingBeatingFromCurrentMoveSequence(move, 0);
-            } else {
-                findAStandardBeatingFromCurrentMoveSequence(move);
-            }
-
-            basicBitSets.getFreeTileNumbers().clear(kingPosition);
         }
-    }
-
-    private void findAFlyingBeatingFromCurrentMoveSequence(Move move, int comingDirection) {
-        if (comingDirection != directions.lowerLeft) checkForPromotedBeatingInDirection(move, directions.upperRight);
-        if (comingDirection != directions.lowerRight) checkForPromotedBeatingInDirection(move, directions.upperLeft);
-        if (comingDirection != directions.upperRight) checkForPromotedBeatingInDirection(move, directions.lowerLeft);
-        if (comingDirection != directions.upperLeft) checkForPromotedBeatingInDirection(move, directions.lowerRight);
-    }
-
-    private void checkForPromotedBeatingInDirection(Move move, int direction) {
-        int endTileNumber = move.getLastPositionOfThePiece();
-        int enemyTileNumber = findClosestEnemyInDirectionFromTile(direction, endTileNumber);
-        if (properEnemyWasFound(enemyTileNumber)) {
-            int expectedFreeTileNumber = enemyTileNumber + direction;
-            basicBitSets.getEnemyPieces().clear(enemyTileNumber); //this will be fixed after finding all (if any) further beatings
-
-            while (basicBitSets.getFreeTileNumbers().get(expectedFreeTileNumber)) {
-                Move updatedMove = move.getCopy();
-                updatedMove.addNewTileNumberToMoveSequence(enemyTileNumber);
-
-
-                updatedMove.addNewTileNumberToMoveSequence(expectedFreeTileNumber);
-                updateAvailableMoves(updatedMove);
-
-                findAFlyingBeatingFromCurrentMoveSequence(updatedMove, direction);
-
-                expectedFreeTileNumber += direction;
-            }
-
-            basicBitSets.getEnemyPieces().set(enemyTileNumber);
-        }
-    }
-
-    private void updateAvailableMoves(Move foundMove) {
-        if (foundMove.size() > currentBeatingLength) {
-            availableMoves.clear();
-            availableMoves.add(foundMove);
-            currentBeatingLength = foundMove.size();
-        } else if (foundMove.size() == currentBeatingLength) {
-            availableMoves.add(foundMove);
-        }
-    }
-
-    private boolean properEnemyWasFound(int enemyPosition) {
-        return enemyPosition > -1;
-    }
-
-    private int findClosestEnemyInDirectionFromTile(int direction, int currentKingPosition) {
-        int checkedPosition = currentKingPosition + direction;
-
-        while (basicBitSets.getFreeTileNumbers().get(checkedPosition)) {
-            checkedPosition += direction;
-        }
-
-        if (basicBitSets.getEnemyPieces().get(checkedPosition)) return checkedPosition;
-        else return -1;
-    }
-
-
-    private void checkForPromotedMoves() {
-        if (moveFinderSettings.isFlyingKingEnabled()) {
-            checkForFlyingMoveInDirection(directions.upperRight);
-            checkForFlyingMoveInDirection(directions.upperLeft);
-            checkForFlyingMoveInDirection(directions.lowerRight);
-            checkForFlyingMoveInDirection(directions.lowerLeft);
-        } else {
-            checkForStandardMoveInDirection(basicBitSets.getOwnKings(), directions.upperLeft);
-            checkForStandardMoveInDirection(basicBitSets.getOwnKings(), directions.upperRight);
-            checkForStandardMoveInDirection(basicBitSets.getOwnKings(), directions.lowerLeft);
-            checkForStandardMoveInDirection(basicBitSets.getOwnKings(), directions.lowerRight);
-        }
-    }
-
-    private void checkForFlyingMoveInDirection(int direction) {
-        int totalDirection = direction;
-        BitSet shiftedCopy = bitwiseOperator.getShiftedCopy(basicBitSets.getOwnKings(), direction);
-        shiftedCopy.and(basicBitSets.getFreeTileNumbers());
-
-        while (!shiftedCopy.isEmpty()) {
-            for (int i = shiftedCopy.nextSetBit(0); i >= 0; i = shiftedCopy.nextSetBit(i + 1)) {
-                availableMoves.add(new Move(i - totalDirection, i));
-            }
-
-            totalDirection += direction;
-            shiftedCopy = bitwiseOperator.getShiftedCopy(shiftedCopy, direction);
-            shiftedCopy.and(basicBitSets.getFreeTileNumbers());
-        }
-
-    }
-
-    private void checkForStandardMove() {
-        if (isWhiteMove) {
-            checkForStandardMoveInDirection(basicBitSets.getOwnCheckers(), directions.upperLeft);
-            checkForStandardMoveInDirection(basicBitSets.getOwnCheckers(), directions.upperRight);
-        } else {
-            checkForStandardMoveInDirection(basicBitSets.getOwnCheckers(), directions.lowerLeft);
-            checkForStandardMoveInDirection(basicBitSets.getOwnCheckers(), directions.lowerRight);
-        }
-
-    }
-
-    private void checkForStandardMoveInDirection(BitSet piecesToCheck, int direction) {
-        BitSet shiftedCopy = bitwiseOperator.getShiftedCopy(piecesToCheck, direction);
-        shiftedCopy.and(basicBitSets.getFreeTileNumbers());
-
-        for (int i = shiftedCopy.nextSetBit(0); i >= 0; i = shiftedCopy.nextSetBit(i + 1)) {
-            availableMoves.add(new Move(i - direction, i));
-        }
-
     }
 
     private boolean noBeatingWasFound() {

--- a/src/model/move_finder/PossibleMovesFinder.java
+++ b/src/model/move_finder/PossibleMovesFinder.java
@@ -21,6 +21,7 @@ public class PossibleMovesFinder {
     private int lowerRight = -5;
     private int lowerLeft = -4;
 
+    private MoveFinderSettings moveFinderSettings;
     private int currentBeatingLength;
     private BitSet freeTileNumbers;
     private BitSet ownCheckers;
@@ -31,7 +32,8 @@ public class PossibleMovesFinder {
     private boolean isWhiteMove;
 
 
-    public PossibleMovesFinder(int boardSideLength) {
+    public PossibleMovesFinder(MoveFinderSettings moveFinderSettings, int boardSideLength) {
+        this.moveFinderSettings = moveFinderSettings;
         bitwiseOperator = new BitwiseOperator(boardSideLength);
 
         declareProperDirections(boardSideLength);

--- a/src/model/move_finder/PossibleMovesFinder.java
+++ b/src/model/move_finder/PossibleMovesFinder.java
@@ -246,9 +246,4 @@ public class PossibleMovesFinder {
         ownCheckers = bitwiseOperator.getOwnCheckers(ownPieces, position.getKings());
         ownKings = bitwiseOperator.getOwnKings(ownPieces, position.getKings());
     }
-
-    public boolean isMovePossible(Position position, Move move, boolean isWhiteMove) {
-        return getAvailableMovesFrom(position, isWhiteMove).contains(move);
-        //TODO: it's probably possible to use here some of the private methods instead of whole public method
-    }
 }

--- a/src/model/move_finder/PossibleMovesFinder.java
+++ b/src/model/move_finder/PossibleMovesFinder.java
@@ -199,16 +199,16 @@ public class PossibleMovesFinder {
 
     private void checkForStandardMove() {
         if (isWhiteMove) {
-            checkFrStandardMoveInDirection(directions.upperLeft);
-            checkFrStandardMoveInDirection(directions.upperRight);
+            checkForStandardMoveInDirection(directions.upperLeft);
+            checkForStandardMoveInDirection(directions.upperRight);
         } else {
-            checkFrStandardMoveInDirection(directions.lowerLeft);
-            checkFrStandardMoveInDirection(directions.lowerRight);
+            checkForStandardMoveInDirection(directions.lowerLeft);
+            checkForStandardMoveInDirection(directions.lowerRight);
         }
 
     }
 
-    private void checkFrStandardMoveInDirection(int direction) {
+    private void checkForStandardMoveInDirection(int direction) {
         BitSet shiftedCopy = bitwiseOperator.getShiftedCopy(basicBitSets.getOwnCheckers(), direction);
         shiftedCopy.and(basicBitSets.getFreeTileNumbers());
 

--- a/src/model/move_finder/PossibleMovesFinder.java
+++ b/src/model/move_finder/PossibleMovesFinder.java
@@ -59,7 +59,7 @@ public class PossibleMovesFinder {
         lowerLeft = (-1) * upperRight;
     }
 
-    public List<Move> getAvailableMovesFrom(Position position, boolean isWhiteMove) { //TODO make available for different board sizes
+    public List<Move> getAvailableMovesFrom(Position position, boolean isWhiteMove) {
 
         this.isWhiteMove = isWhiteMove;
         availableMoves = new LinkedList<>();

--- a/src/model/move_finder/PossibleMovesFinderTest.java
+++ b/src/model/move_finder/PossibleMovesFinderTest.java
@@ -496,6 +496,33 @@ class PossibleMovesFinderTest {
      */
 
     @Test
+    void shouldNotAllowFlyingBeatings() {
+        prepareBitSetsAndPositionFinderForBoardSideLength(BOARD_SIDE_LENGTH_TWELVE);
+
+        MoveFinderSettings customMoveFinderSettings = new MoveFinderSettings(false, true);
+        possibleMovesFinder = new PossibleMovesFinder(customMoveFinderSettings, BOARD_SIDE_LENGTH_TWELVE);
+
+        whitePieces.set(47);
+        whitePieces.set(17);
+        whitePieces.set(43);
+        whitePieces.set(15);
+
+        blackPieces.set(29);
+        kings.set(29);
+
+        expectedMoveList.add(new Move(29, 35));
+        expectedMoveList.add(new Move(29, 36));
+        expectedMoveList.add(new Move(29, 22));
+        expectedMoveList.add(new Move(29, 23));
+
+        actualMoveList = possibleMovesFinder.getAvailableMovesFrom(position, IS_WHITE_TURN);
+
+        sortBothLists();
+
+        assertEquals(expectedMoveList, actualMoveList);
+    }
+
+    @Test
     void shouldFindAllBeatingsForCheckers() {
         prepareBitSetsAndPositionFinderForBoardSideLength(BOARD_SIDE_LENGTH_TWELVE);
 

--- a/src/model/move_finder/PossibleMovesFinderTest.java
+++ b/src/model/move_finder/PossibleMovesFinderTest.java
@@ -80,14 +80,15 @@ class PossibleMovesFinderTest {
         MoveFinderSettings customMoveFinderSettings = new MoveFinderSettings(true, false);
         possibleMovesFinder = new PossibleMovesFinder(customMoveFinderSettings, BOARD_SIDE_LENGTH_EIGHT);
 
-        whitePieces.set(20);
-        whitePieces.set(19);
-        blackPieces.set(24);
+        blackPieces.set(20);
+        blackPieces.set(19);
+
+        whitePieces.set(24);
 
         expectedMoveList.add(new Move(24, 29));
         expectedMoveList.add(new Move(24, 28));
 
-        actualMoveList = possibleMovesFinder.getAvailableMovesFrom(position, IS_BLACK_TURN);
+        actualMoveList = possibleMovesFinder.getAvailableMovesFrom(position, IS_WHITE_TURN);
 
         sortBothLists();
 
@@ -101,14 +102,14 @@ class PossibleMovesFinderTest {
         MoveFinderSettings customMoveFinderSettings = new MoveFinderSettings(true, false);
         possibleMovesFinder = new PossibleMovesFinder(customMoveFinderSettings, BOARD_SIDE_LENGTH_EIGHT);
 
-        whitePieces.set(25);
-        whitePieces.set(34);
-        whitePieces.set(33);
+        blackPieces.set(25);
+        blackPieces.set(34);
+        blackPieces.set(33);
 
-        blackPieces.set(20);
+        whitePieces.set(20);
 
         expectedMoveList.add(new Move(20, 25, 30, 34, 38));
-        actualMoveList = possibleMovesFinder.getAvailableMovesFrom(position, IS_BLACK_TURN);
+        actualMoveList = possibleMovesFinder.getAvailableMovesFrom(position, IS_WHITE_TURN);
 
         sortBothLists();
 
@@ -353,13 +354,13 @@ class PossibleMovesFinderTest {
         MoveFinderSettings customMoveFinderSettings = new MoveFinderSettings(false, false);
         possibleMovesFinder = new PossibleMovesFinder(customMoveFinderSettings, BOARD_SIDE_LENGTH_TEN);
 
-        whitePieces.set(35);
-        whitePieces.set(34);
-        whitePieces.set(53);
-        whitePieces.set(25);
+        blackPieces.set(35);
+        blackPieces.set(34);
+        blackPieces.set(53);
+        blackPieces.set(25);
 
-        blackPieces.set(40);
-        blackPieces.set(43);
+        whitePieces.set(40);
+        whitePieces.set(43);
         kings.set(43);
 
         expectedMoveList.add(new Move(40, 46));
@@ -367,7 +368,7 @@ class PossibleMovesFinderTest {
         expectedMoveList.add(new Move(43, 48));
         expectedMoveList.add(new Move(43, 37));
 
-        actualMoveList = possibleMovesFinder.getAvailableMovesFrom(position, IS_BLACK_TURN);
+        actualMoveList = possibleMovesFinder.getAvailableMovesFrom(position, IS_WHITE_TURN);
 
         sortBothLists();
 

--- a/src/model/move_finder/PossibleMovesFinderTest.java
+++ b/src/model/move_finder/PossibleMovesFinderTest.java
@@ -496,6 +496,30 @@ class PossibleMovesFinderTest {
      */
 
     @Test
+    void shouldAllowPromotedBeatingButNotFlyingOne() {
+        prepareBitSetsAndPositionFinderForBoardSideLength(BOARD_SIDE_LENGTH_TWELVE);
+
+        MoveFinderSettings customMoveFinderSettings = new MoveFinderSettings(false, true);
+        possibleMovesFinder = new PossibleMovesFinder(customMoveFinderSettings, BOARD_SIDE_LENGTH_TWELVE);
+
+        whitePieces.set(49);
+        whitePieces.set(36);
+
+        blackPieces.set(42);
+        kings.set(42);
+
+        expectedMoveList.add(new Move(42, 49, 56));
+        expectedMoveList.add(new Move(42, 36, 30));
+        // notice lack of flying beatings like (42, 49, 63), (42, 49, 70)...
+
+        actualMoveList = possibleMovesFinder.getAvailableMovesFrom(position, IS_BLACK_TURN);
+
+        sortBothLists();
+
+        assertEquals(expectedMoveList, actualMoveList);
+    }
+
+    @Test
     void shouldNotAllowFlyingBeatings() {
         prepareBitSetsAndPositionFinderForBoardSideLength(BOARD_SIDE_LENGTH_TWELVE);
 

--- a/src/model/move_finder/PossibleMovesFinderTest.java
+++ b/src/model/move_finder/PossibleMovesFinderTest.java
@@ -515,7 +515,7 @@ class PossibleMovesFinderTest {
         expectedMoveList.add(new Move(29, 22));
         expectedMoveList.add(new Move(29, 23));
 
-        actualMoveList = possibleMovesFinder.getAvailableMovesFrom(position, IS_WHITE_TURN);
+        actualMoveList = possibleMovesFinder.getAvailableMovesFrom(position, IS_BLACK_TURN);
 
         sortBothLists();
 

--- a/src/model/move_finder/PossibleMovesFinderTest.java
+++ b/src/model/move_finder/PossibleMovesFinderTest.java
@@ -73,6 +73,27 @@ class PossibleMovesFinderTest {
         |08  07  06  05  |
      */
 
+    @Test
+    void shouldStopCheckerAtPromotionLineWithNoBackwardBeatingsEnabled() {
+        prepareBitSetsAndPositionFinderForBoardSideLength(BOARD_SIDE_LENGTH_EIGHT);
+
+        MoveFinderSettings customMoveFinderSettings = new MoveFinderSettings(true, false);
+        possibleMovesFinder = new PossibleMovesFinder(customMoveFinderSettings, BOARD_SIDE_LENGTH_EIGHT);
+
+        whitePieces.set(25);
+        whitePieces.set(34);
+        whitePieces.set(33);
+
+        blackPieces.set(20);
+
+        expectedMoveList.add(new Move(20, 25, 30, 34, 38));
+        actualMoveList = possibleMovesFinder.getAvailableMovesFrom(position, IS_BLACK_TURN);
+
+        sortBothLists();
+
+        assertEquals(expectedMoveList, actualMoveList);
+    }
+
 
     @Test
     void shouldReturnAllPossibleMovesFromStartingPosition() {

--- a/src/model/move_finder/PossibleMovesFinderTest.java
+++ b/src/model/move_finder/PossibleMovesFinderTest.java
@@ -74,6 +74,27 @@ class PossibleMovesFinderTest {
      */
 
     @Test
+    void shouldNotAllowCheckerBeatingBackwards() {
+        prepareBitSetsAndPositionFinderForBoardSideLength(BOARD_SIDE_LENGTH_EIGHT);
+
+        MoveFinderSettings customMoveFinderSettings = new MoveFinderSettings(true, false);
+        possibleMovesFinder = new PossibleMovesFinder(customMoveFinderSettings, BOARD_SIDE_LENGTH_EIGHT);
+
+        whitePieces.set(20);
+        whitePieces.set(19);
+        blackPieces.set(24);
+
+        expectedMoveList.add(new Move(24, 29));
+        expectedMoveList.add(new Move(24, 28));
+
+        actualMoveList = possibleMovesFinder.getAvailableMovesFrom(position, IS_BLACK_TURN);
+
+        sortBothLists();
+
+        assertEquals(expectedMoveList, actualMoveList);
+    }
+
+    @Test
     void shouldStopCheckerAtPromotionLineWithNoBackwardBeatingsEnabled() {
         prepareBitSetsAndPositionFinderForBoardSideLength(BOARD_SIDE_LENGTH_EIGHT);
 

--- a/src/model/move_finder/PossibleMovesFinderTest.java
+++ b/src/model/move_finder/PossibleMovesFinderTest.java
@@ -395,7 +395,7 @@ class PossibleMovesFinderTest {
     }
 
     /*
-    |  59  58  57  56  55|
+      |  59  58  57  56  55|
       |54  53  52  51  50  |
       |  48  47  46  45  44|
       |43  42  41  40  39  |
@@ -406,6 +406,29 @@ class PossibleMovesFinderTest {
       |  15  14  13  12  11|
       |10  09  08  07  06  |
      */
+
+    @Test
+    void shouldNotAllowFlyingMovesForKing() {
+        prepareBitSetsAndPositionFinderForBoardSideLength(BOARD_SIDE_LENGTH_TEN);
+
+        MoveFinderSettings customMoveFinderSettings = new MoveFinderSettings(false, true);
+        possibleMovesFinder = new PossibleMovesFinder(customMoveFinderSettings, BOARD_SIDE_LENGTH_TEN);
+
+        whitePieces.set(19);
+        kings.set(19);
+        blackPieces.set(22);
+
+        expectedMoveList.add(new Move(19, 25));
+        expectedMoveList.add(new Move(19, 24));
+        expectedMoveList.add(new Move(19, 13));
+        expectedMoveList.add(new Move(19, 14));
+
+        actualMoveList = possibleMovesFinder.getAvailableMovesFrom(position, IS_WHITE_TURN);
+
+        sortBothLists();
+
+        assertEquals(expectedMoveList, actualMoveList);
+    }
 
     @Test
     void shouldFindAllPossibleMovesForStartingPosition() {

--- a/src/model/move_finder/PossibleMovesFinderTest.java
+++ b/src/model/move_finder/PossibleMovesFinderTest.java
@@ -347,6 +347,34 @@ class PossibleMovesFinderTest {
      */
 
     @Test
+    void shouldSeeOnlyNotBeatingMovesDueToDisabledFlyingKingsAndCheckerBackwardBeatingNotEnabled() {
+        prepareBitSetsAndPositionFinderForBoardSideLength(BOARD_SIDE_LENGTH_TEN);
+
+        MoveFinderSettings customMoveFinderSettings = new MoveFinderSettings(false, false);
+        possibleMovesFinder = new PossibleMovesFinder(customMoveFinderSettings, BOARD_SIDE_LENGTH_TEN);
+
+        whitePieces.set(35);
+        whitePieces.set(34);
+        whitePieces.set(53);
+        whitePieces.set(25);
+
+        blackPieces.set(40);
+        blackPieces.set(43);
+        kings.set(43);
+
+        expectedMoveList.add(new Move(40, 46));
+        expectedMoveList.add(new Move(40, 45));
+        expectedMoveList.add(new Move(43, 48));
+        expectedMoveList.add(new Move(43, 37));
+
+        actualMoveList = possibleMovesFinder.getAvailableMovesFrom(position, IS_BLACK_TURN);
+
+        sortBothLists();
+
+        assertEquals(expectedMoveList, actualMoveList);
+    }
+
+    @Test
     void shouldFindProperMovesForKing() {
         prepareBitSetsAndPositionFinderForBoardSideLength(BOARD_SIDE_LENGTH_TEN);
 

--- a/src/model/move_finder/PossibleMovesFinderTest.java
+++ b/src/model/move_finder/PossibleMovesFinderTest.java
@@ -647,5 +647,28 @@ class PossibleMovesFinderTest {
         assertEquals(expectedMoveList, actualMoveList);
     }
 
+    @Test
+    void shouldNotFlyingKingBeatBackwardWithCheckerBackwardBeatingDisabled() {
+        prepareBitSetsAndPositionFinderForBoardSideLength(BOARD_SIDE_LENGTH_EIGHT);
+
+        MoveFinderSettings customMoveFinderSettings = new MoveFinderSettings(false, false);
+        possibleMovesFinder = new PossibleMovesFinder(customMoveFinderSettings, BOARD_SIDE_LENGTH_EIGHT);
+
+        blackPieces.set(20);
+        blackPieces.set(19);
+
+        whitePieces.set(24);
+        kings.set(24);
+
+        expectedMoveList.add(new Move(24, 20, 16));
+        expectedMoveList.add(new Move(24, 19, 14));
+
+        actualMoveList = possibleMovesFinder.getAvailableMovesFrom(position, IS_WHITE_TURN);
+
+        sortBothLists();
+
+        assertEquals(expectedMoveList, actualMoveList);
+    }
+
 
 }

--- a/src/model/move_finder/PossibleMovesFinderTest.java
+++ b/src/model/move_finder/PossibleMovesFinderTest.java
@@ -35,7 +35,8 @@ class PossibleMovesFinderTest {
 
     void prepareBitSetsAndPositionFinderForBoardSideLength(int boardSideLength) {
         // before each test, the position is empty (all bits in BitSets are set to 0)
-        possibleMovesFinder = new PossibleMovesFinder(boardSideLength);
+        MoveFinderSettings moveFinderSettings = new MoveFinderSettings(true, true);
+        possibleMovesFinder = new PossibleMovesFinder(moveFinderSettings, boardSideLength);
         position = positionGenerator.generateEmptyPositionForBoardSide(boardSideLength);
         whitePieces = position.getWhitePieces();
         blackPieces = position.getBlackPieces();

--- a/src/model/move_finder/move_finder_beating_strategy/FlyingBeating.java
+++ b/src/model/move_finder/move_finder_beating_strategy/FlyingBeating.java
@@ -1,0 +1,59 @@
+package model.move_finder.move_finder_beating_strategy;
+
+import model.board.Move;
+import model.move_finder.DirectionsValueBySize;
+
+public class FlyingBeating extends MoveFinderBeatingStrategy {
+    public FlyingBeating(DirectionsValueBySize directions) {
+        super(directions);
+    }
+
+    @Override
+    void findBeatingMovesFromMoveSequence(Move move) {
+        checkForBeatingMoveInDirection(move, directions.upperRight);
+        checkForBeatingMoveInDirection(move, directions.upperLeft);
+        checkForBeatingMoveInDirection(move, directions.lowerRight);
+        checkForBeatingMoveInDirection(move, directions.lowerLeft);
+    }
+
+    @Override
+    void checkForBeatingMoveInDirection(Move move, int direction) {
+        int kingTileNumber = move.getLastPositionOfThePiece();
+        int nextNotFreeTile = skipFreeTiles(kingTileNumber, direction);
+
+        if (currentBasicBitSets.getEnemyPieces().get(nextNotFreeTile)) {
+            currentBasicBitSets.getEnemyPieces().clear(nextNotFreeTile);
+
+            int expectedFreeTile = nextNotFreeTile + direction;
+
+            while (currentBasicBitSets.getFreeTileNumbers().get(expectedFreeTile)) {
+                Move foundMove = move.getCopy();
+                foundMove.addNewTileNumberToMoveSequence(nextNotFreeTile);
+                foundMove.addNewTileNumberToMoveSequence(expectedFreeTile);
+
+                updateFoundMoves(foundMove);
+
+                findBeatingMovesFromMoveSequenceFromDirection(foundMove, direction);
+
+                expectedFreeTile += direction;
+            }
+            currentBasicBitSets.getEnemyPieces().set(nextNotFreeTile);
+        }
+    }
+
+    private void findBeatingMovesFromMoveSequenceFromDirection(Move move, int comingDirection) {
+        if (comingDirection != directions.upperRight) checkForBeatingMoveInDirection(move, directions.upperRight);
+        if (comingDirection != directions.upperLeft) checkForBeatingMoveInDirection(move, directions.upperLeft);
+        if (comingDirection != directions.lowerRight) checkForBeatingMoveInDirection(move, directions.lowerRight);
+        if (comingDirection != directions.lowerLeft) checkForBeatingMoveInDirection(move, directions.lowerLeft);
+    }
+
+    private int skipFreeTiles(int kingTileNumber, int direction) {
+        int expectedNotFreeTileNumber = kingTileNumber + direction;
+
+        while (currentBasicBitSets.getFreeTileNumbers().get(expectedNotFreeTileNumber)) {
+            expectedNotFreeTileNumber += direction;
+        }
+        return expectedNotFreeTileNumber;
+    }
+}

--- a/src/model/move_finder/move_finder_beating_strategy/ForwardBeating.java
+++ b/src/model/move_finder/move_finder_beating_strategy/ForwardBeating.java
@@ -1,0 +1,16 @@
+package model.move_finder.move_finder_beating_strategy;
+
+import model.board.Move;
+import model.move_finder.DirectionsValueBySize;
+
+public class ForwardBeating extends NotFlyingBeatingStrategy {
+    public ForwardBeating(DirectionsValueBySize directions) {
+        super(directions);
+    }
+
+    @Override
+    void findBeatingMovesFromMoveSequence(Move move) {
+        checkForBeatingMoveInDirection(move, frontLeftDirectionValue);
+        checkForBeatingMoveInDirection(move, frontRightDirectionValue);
+    }
+}

--- a/src/model/move_finder/move_finder_beating_strategy/MoveFinderBeatingStrategy.java
+++ b/src/model/move_finder/move_finder_beating_strategy/MoveFinderBeatingStrategy.java
@@ -2,6 +2,7 @@ package model.move_finder.move_finder_beating_strategy;
 
 import model.board.Move;
 import model.move_finder.BasicBitSets;
+import model.move_finder.DirectionsValueBySize;
 
 import java.util.LinkedList;
 import java.util.List;
@@ -10,6 +11,13 @@ public abstract class MoveFinderBeatingStrategy {
     protected BasicBitSets currentBasicBitSets;
     private List<Move> foundMoves;
     private int longestBeatingFoundSize;
+    private DirectionsValueBySize directions;
+    private int frontLeftDirectionValue;
+    private int frontRightDirectionValue;
+
+    public MoveFinderBeatingStrategy(DirectionsValueBySize directions) {
+        this.directions = directions;
+    }
 
     public List<Move> checkForBeatingMoves(int startingTileNumber, BasicBitSets basicBitSets) {
         foundMoves = new LinkedList<>();
@@ -22,9 +30,6 @@ public abstract class MoveFinderBeatingStrategy {
         return foundMoves;
     }
 
-    abstract void findBeatingMovesFromMoveSequence(Move move);
-    abstract void checkForBeatingMoveInDirection();
-
     void updateFoundMoves(Move move) {
         if (move.size() > longestBeatingFoundSize) {
             foundMoves.clear();
@@ -34,4 +39,17 @@ public abstract class MoveFinderBeatingStrategy {
             foundMoves.add(move);
         }
     }
+
+    public void setForwardDirection(boolean isWhiteMove) {
+        if (isWhiteMove) {
+            frontLeftDirectionValue = directions.upperLeft;
+            frontRightDirectionValue = directions.upperRight;
+        } else {
+            frontLeftDirectionValue = directions.lowerLeft;
+            frontRightDirectionValue = directions.lowerRight;
+        }
+    }
+
+    abstract void findBeatingMovesFromMoveSequence(Move move);
+    abstract void checkForBeatingMoveInDirection(Move move, int direction);
 }

--- a/src/model/move_finder/move_finder_beating_strategy/MoveFinderBeatingStrategy.java
+++ b/src/model/move_finder/move_finder_beating_strategy/MoveFinderBeatingStrategy.java
@@ -11,9 +11,9 @@ public abstract class MoveFinderBeatingStrategy {
     protected BasicBitSets currentBasicBitSets;
     private List<Move> foundMoves;
     private int longestBeatingFoundSize;
-    private DirectionsValueBySize directions;
-    private int frontLeftDirectionValue;
-    private int frontRightDirectionValue;
+    DirectionsValueBySize directions;
+    int frontLeftDirectionValue;
+    int frontRightDirectionValue;
 
     public MoveFinderBeatingStrategy(DirectionsValueBySize directions) {
         this.directions = directions;
@@ -24,8 +24,12 @@ public abstract class MoveFinderBeatingStrategy {
         currentBasicBitSets = basicBitSets;
         longestBeatingFoundSize = 0;
 
+        currentBasicBitSets.getFreeTileNumbers().set(startingTileNumber);
+
         Move startingMove = new Move(startingTileNumber);
         findBeatingMovesFromMoveSequence(startingMove);
+
+        currentBasicBitSets.getFreeTileNumbers().clear(startingTileNumber);
 
         return foundMoves;
     }
@@ -51,5 +55,6 @@ public abstract class MoveFinderBeatingStrategy {
     }
 
     abstract void findBeatingMovesFromMoveSequence(Move move);
+
     abstract void checkForBeatingMoveInDirection(Move move, int direction);
 }

--- a/src/model/move_finder/move_finder_beating_strategy/MoveFinderBeatingStrategy.java
+++ b/src/model/move_finder/move_finder_beating_strategy/MoveFinderBeatingStrategy.java
@@ -1,0 +1,37 @@
+package model.move_finder.move_finder_beating_strategy;
+
+import model.board.Move;
+import model.move_finder.BasicBitSets;
+
+import java.util.LinkedList;
+import java.util.List;
+
+public abstract class MoveFinderBeatingStrategy {
+    protected BasicBitSets currentBasicBitSets;
+    private List<Move> foundMoves;
+    private int longestBeatingFoundSize;
+
+    public List<Move> checkForBeatingMoves(int startingTileNumber, BasicBitSets basicBitSets) {
+        foundMoves = new LinkedList<>();
+        currentBasicBitSets = basicBitSets;
+        longestBeatingFoundSize = 0;
+
+        Move startingMove = new Move(startingTileNumber);
+        findBeatingMovesFromMoveSequence(startingMove);
+
+        return foundMoves;
+    }
+
+    abstract void findBeatingMovesFromMoveSequence(Move move);
+    abstract void checkForBeatingMoveInDirection();
+
+    void updateFoundMoves(Move move) {
+        if (move.size() > longestBeatingFoundSize) {
+            foundMoves.clear();
+            foundMoves.add(move);
+            longestBeatingFoundSize = move.size();
+        } else if (move.size() == longestBeatingFoundSize) {
+            foundMoves.add(move);
+        }
+    }
+}

--- a/src/model/move_finder/move_finder_beating_strategy/NotFlyingBeatingStrategy.java
+++ b/src/model/move_finder/move_finder_beating_strategy/NotFlyingBeatingStrategy.java
@@ -1,0 +1,33 @@
+package model.move_finder.move_finder_beating_strategy;
+
+import model.board.Move;
+import model.move_finder.DirectionsValueBySize;
+
+public abstract class NotFlyingBeatingStrategy extends MoveFinderBeatingStrategy {
+    public NotFlyingBeatingStrategy(DirectionsValueBySize directions) {
+        super(directions);
+    }
+
+    @Override
+    void checkForBeatingMoveInDirection(Move move, int direction) {
+        int pieceTileNumber = move.getLastPositionOfThePiece();
+        int expectedEnemyTile = pieceTileNumber + direction;
+        int expectedFreeTile = expectedEnemyTile + direction;
+
+        if (currentBasicBitSets.getEnemyPieces().get(expectedEnemyTile)) {
+            if (currentBasicBitSets.getFreeTileNumbers().get(expectedFreeTile)) {
+                currentBasicBitSets.getEnemyPieces().clear(expectedEnemyTile);
+
+                Move foundMove = move.getCopy();
+                foundMove.addNewTileNumberToMoveSequence(expectedEnemyTile);
+                foundMove.addNewTileNumberToMoveSequence(expectedFreeTile);
+
+                updateFoundMoves(foundMove);
+
+                findBeatingMovesFromMoveSequence(foundMove);
+
+                currentBasicBitSets.getEnemyPieces().set(expectedEnemyTile);
+            }
+        }
+    }
+}

--- a/src/model/move_finder/move_finder_beating_strategy/StandardBeating.java
+++ b/src/model/move_finder/move_finder_beating_strategy/StandardBeating.java
@@ -1,0 +1,18 @@
+package model.move_finder.move_finder_beating_strategy;
+
+import model.board.Move;
+import model.move_finder.DirectionsValueBySize;
+
+public class StandardBeating extends NotFlyingBeatingStrategy {
+    public StandardBeating(DirectionsValueBySize directions) {
+        super(directions);
+    }
+
+    @Override
+    void findBeatingMovesFromMoveSequence(Move move) {
+        checkForBeatingMoveInDirection(move, directions.upperRight);
+        checkForBeatingMoveInDirection(move, directions.upperLeft);
+        checkForBeatingMoveInDirection(move, directions.lowerRight);
+        checkForBeatingMoveInDirection(move, directions.lowerLeft);
+    }
+}

--- a/src/view/MainView.java
+++ b/src/view/MainView.java
@@ -87,4 +87,12 @@ public class MainView {
     public void setMovesTillDraw(int movesTillDraw) {
         Platform.runLater(() -> movesTillDrawLabel.setText(String.valueOf(movesTillDraw)));
     }
+
+    public boolean isFlyingKingEnabled() {
+        return flyingKingsCheckBox.isSelected();
+    }
+
+    public boolean isCheckerBeatingBackwardEnabled() {
+        return checkersCanBeatBackwardsCheckBox.isSelected();
+    }
 }

--- a/src/view/MainView.java
+++ b/src/view/MainView.java
@@ -32,6 +32,12 @@ public class MainView {
     @FXML
     private Slider boardSizeSlider;
 
+    @FXML
+    private CheckBox flyingKingsCheckBox;
+
+    @FXML
+    private CheckBox checkersCanBeatBackwardsCheckBox;
+
     private MainViewController mainViewController;
 
     @FXML

--- a/src/view/mainView.fxml
+++ b/src/view/mainView.fxml
@@ -5,10 +5,8 @@
 <?import javafx.scene.control.CheckBox?>
 <?import javafx.scene.control.ComboBox?>
 <?import javafx.scene.control.Label?>
-<?import javafx.scene.control.RadioButton?>
 <?import javafx.scene.control.Slider?>
 <?import javafx.scene.control.SplitPane?>
-<?import javafx.scene.control.ToggleGroup?>
 <?import javafx.scene.layout.AnchorPane?>
 <?import javafx.scene.layout.BorderPane?>
 <?import javafx.scene.layout.HBox?>
@@ -48,18 +46,13 @@
                                     <Insets left="10.0" />
                                  </VBox.margin>
                               </HBox>
-                              <VBox prefHeight="200.0" prefWidth="100.0">
+                              <VBox prefHeight="200.0" prefWidth="100.0" spacing="6.0">
                                  <children>
-                                    <RadioButton alignment="CENTER_LEFT" mnemonicParsing="false" selected="true" text="Flying king, men can capture backwards">
-                                       <toggleGroup>
-                                          <ToggleGroup fx:id="kingSettings" />
-                                       </toggleGroup>
-                                    </RadioButton>
-                                    <RadioButton alignment="CENTER_RIGHT" mnemonicParsing="false" text="Flying kings, men can't capture backwards" toggleGroup="$kingSettings" />
-                                    <RadioButton alignment="CENTER_RIGHT" mnemonicParsing="false" text="No flying kings, men can't capture backwards" toggleGroup="$kingSettings" />
+                                    <CheckBox fx:id="flyingKingsCheckBox" mnemonicParsing="false" selected="true" text="Flying kings" />
+                                    <CheckBox fx:id="checkersCanBeatBackwardsCheckBox" mnemonicParsing="false" selected="true" text="Checkers can beat backwards" />
                                  </children>
                                  <VBox.margin>
-                                    <Insets left="5.0" />
+                                    <Insets left="10.0" />
                                  </VBox.margin>
                               </VBox>
                               <CheckBox fx:id="showTileNumbersCheckBox" mnemonicParsing="false" text="Show tile numbers" />


### PR DESCRIPTION
Player can now choose whether:
- checker beating backward is enabled
- flying king is enabled

If flying king is not enabled, kings can move one tile in any direction and beat like checker (with backward beating)

Player can choose the options before starting the game (via checkBoxes).
Most changes at PossibleMovesFinder, some code moved to other classes.
Tests added for new functionality.